### PR TITLE
【修正】カテゴリー表示・basic認証

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :basic_auth, if: :production?
 
   private
   def configure_permitted_parameters

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -36,9 +36,13 @@
         .show__main__top__table__box2
           .show__main__top__table__box2__left カテゴリー
           .show__main__top__table__box2__right
-            %p= @item.category.root.name
-            %p= @item.category.parent.name
-            %p= @item.category.name
+            - if @item.category.root == @item.category.parent
+              %p= @item.category.root.name
+              %p= @item.category.name
+            - else
+              %p= @item.category.root.name
+              %p= @item.category.parent.name
+              %p= @item.category.name
         .show__main__top__table__box3
           .show__main__top__table__box3__left 商品の状態
           .show__main__top__table__box3__right 


### PR DESCRIPTION
# what 
商品詳細でのカテゴリー表示と、basic認証の設定を編集

# why
・３段階目と２段階目のカテゴリーが同じ際は出力されないようにするため　
・WEBアプリケーションのセキュリティーを向上させるため